### PR TITLE
Using year for movies search - when kodi isn't playing

### DIFF
--- a/resources/lib/OSUtilities.py
+++ b/resources/lib/OSUtilities.py
@@ -41,11 +41,12 @@ class OSDBServer:
                                                 int(item['episode']),)
                                               ).replace(" ","+")      
       else:
-        if str(item['year']) == "":
+        if str(item['year']) == "" and xbmc.Player().isPlaying():
           item['title'], item['year'] = xbmc.getCleanMovieTitle( item['title'] )
     
         OS_search_string = item['title'].replace(" ","+")
     
+
       log( __name__ , "Search String [ %s ]" % (OS_search_string,))
 
       if not item['temp']:

--- a/service.py
+++ b/service.py
@@ -109,7 +109,7 @@ def takeTitleFromFocusedItem():
     labelTVShowTitle = xbmc.getInfoLabel("ListItem.TVShowTitle")
     labelSeason = xbmc.getInfoLabel("ListItem.Season")
     labelEpisode = xbmc.getInfoLabel("ListItem.Episode")
-    labelType = xbmc.getInfoLabel("ListItem.DBTYPE")  #movie/tvshow/season/episode
+    labelType = xbmc.getInfoLabel("ListItem.DBTYPE")  #movie/tvshow/season/episode 
     isItMovie = labelType == 'movie' or xbmc.getCondVisibility("Container.Content(movies)")
     isItEpisode = labelType == 'episode' or xbmc.getCondVisibility("Container.Content(episodes)")
 

--- a/service.py
+++ b/service.py
@@ -109,7 +109,7 @@ def takeTitleFromFocusedItem():
     labelTVShowTitle = xbmc.getInfoLabel("ListItem.TVShowTitle")
     labelSeason = xbmc.getInfoLabel("ListItem.Season")
     labelEpisode = xbmc.getInfoLabel("ListItem.Episode")
-    labelType = xbmc.getInfoLabel("ListItem.DBTYPE")  #movie/tvshow/season/episode 
+    labelType = xbmc.getInfoLabel("ListItem.DBTYPE")  #movie/tvshow/season/episode	
     isItMovie = labelType == 'movie' or xbmc.getCondVisibility("Container.Content(movies)")
     isItEpisode = labelType == 'episode' or xbmc.getCondVisibility("Container.Content(episodes)")
 

--- a/service.py
+++ b/service.py
@@ -109,23 +109,9 @@ def takeTitleFromFocusedItem():
     labelTVShowTitle = xbmc.getInfoLabel("ListItem.TVShowTitle")
     labelSeason = xbmc.getInfoLabel("ListItem.Season")
     labelEpisode = xbmc.getInfoLabel("ListItem.Episode")
-    isItMovie = False
-    isItEpisode = False
     labelType = xbmc.getInfoLabel("ListItem.DBTYPE")  #movie/tvshow/season/episode
-    if labelType:
-        if labelType == 'movie':
-            isItMovie = True
-            isItEpisode = False
-        elif labelType == 'episode':
-            isItMovie = False
-            isItEpisode = True
-    else:
-        if xbmc.getCondVisibility("Container.Content(movies)"):
-            isItMovie = True
-            isItEpisode = False
-        elif xbmc.getCondVisibility("Container.Content(episodes)"):
-            isItMovie = False
-            isItEpisode = True
+    isItMovie = labelType == 'movie' or xbmc.getCondVisibility("Container.Content(movies)")
+    isItEpisode = labelType == 'episode' or xbmc.getCondVisibility("Container.Content(episodes)")
 
     title = 'SearchFor...'
     if isItMovie and labelMovieTitle and labelYear:


### PR DESCRIPTION
Because when kodi isn't playing has empty value for the year which
already attached to the title string.
So when kodi isn't playing there is no need for getCleanMovieTitle.