### PR TITLE
Fixed corner case where __temp__ directory might not exist

### DIFF
--- a/service.py
+++ b/service.py
@@ -88,6 +88,8 @@ def Download(id,url,format,stack=False):
     log( __name__,"Download Using HTTP")
     zip = os.path.join( __temp__, "OpenSubtitles.zip")
     f = urllib.urlopen(url)
+    if not os.path.exists( __temp__ ):
+        os.mkdir( __temp__, mode=0775 )
     with open(zip, "wb") as subFile:
       subFile.write(f.read())
     subFile.close()
@@ -109,7 +111,7 @@ def takeTitleFromFocusedItem():
     labelTVShowTitle = xbmc.getInfoLabel("ListItem.TVShowTitle")
     labelSeason = xbmc.getInfoLabel("ListItem.Season")
     labelEpisode = xbmc.getInfoLabel("ListItem.Episode")
-    labelType = xbmc.getInfoLabel("ListItem.DBTYPE")  #movie/tvshow/season/episode	
+    labelType = xbmc.getInfoLabel("ListItem.DBTYPE")  #movie/tvshow/season/episode
     isItMovie = labelType == 'movie' or xbmc.getCondVisibility("Container.Content(movies)")
     isItEpisode = labelType == 'episode' or xbmc.getCondVisibility("Container.Content(episodes)")
 


### PR DESCRIPTION
This change checks if __temp__ exists and creates it if not. Simple enough and I noticed (even when creating the __temp__ directory manually) when attempting to redownload subtitles after a movie is playing it might get removed by something else and thus not exist throwing an IOError.